### PR TITLE
make per-level sprites use less rom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ asm/uninstall.asm
 asm/overworld.asm
 pixi*.zip
 .vscode
+*.o

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+CXXFLAGS += -fpermissive
+LDFLAGS += -ldl
+
+SOURCES = $(wildcard src/*.cpp) $(wildcard src/MeiMei/*.cpp) src/json/base64.cpp
+
+OBJECTS = $(patsubst %.cpp,%.o,$(SOURCES)) src/asar/asardll.o
+
+pixi: $(OBJECTS)
+	$(CXX) -o $@ $^ $(LDFLAGS)
+
+clean:
+	rm -f pixi $(OBJECTS)
+
+all: pixi

--- a/asm/main.asm
+++ b/asm/main.asm
@@ -22,8 +22,8 @@ TableLoc:
 	; yeah, kinda wasting 4 byte here by having the tables twice.
 	; but the above makes access easier and these are for cleanup.
    if !PerLevel = 1
-        autoclean dl PerLevelTable
-		autoclean dl PerLevelCustomPtrTable
+        autoclean dl PerLevelLvlPtrs
+		dl $FFFFFF
 		dl $FFFFFF
 		dl $FFFFFF
    else
@@ -419,7 +419,7 @@ endif
 	; restore code
 	INX
 	JML $02A82E|!BankB			; return to loop
-   
+
 SubLoadHack:
 	%debugmsg("SubLoadHack")
 	PHA
@@ -602,7 +602,10 @@ GetMainPtr:
 		PLB
 		LDA $00
 		BRA -
-	+	LDA.w PerLevelTable+$0B,y			; load low-high byte of pointer
+	+	PEA.w PerLevelTable>>8
+		PLB
+		PLB
+		LDA.w PerLevelTable+$0B,y			; load low-high byte of pointer
 		STA $00									; 00=low, 01=high, 02=x
 		LDA.w PerLevelTable+$0C,y			; load high-bank byte of pointer
 		STA $01									; 00=low, 01=high, 02=bank
@@ -621,15 +624,20 @@ if !PerLevel = 1
 		LDA $010B|!Base2
 		ASL
 		TAY
-		PEA.w PerLevelTable>>8
+		PEA.w ((PerLevelLvlPtrs>>16)<<8)|(PerLevelSprPtrs>>16)
 		PLB
-		PLB
-		LDA.w PerLevelTable,y
+		; now in PerLevelLvlPtrs bank
+		LDA.w PerLevelLvlPtrs,y
 		BEQ .return
-		ADC $00
+		PLB
+		; now in PerLevelSprPtrs bank
+		ADC $00 ; carry cleared by ASL earlier
 		TAY
-		LDA.w PerLevelTable-($B0*2),y
+		LDA.w PerLevelSprPtrs-($B0*2),y
+		TAY
+		RTS
 	.return
+		PLB
 		TAY
 		RTS
 endif
@@ -1044,7 +1052,10 @@ SetSpriteTables:
 		PLB
 		LDA $00
 		BRA -
-	+	SEP #$20
+	+	PEA.w PerLevelTable>>8
+		PLB
+		PLB
+		SEP #$20
 		LDA.w PerLevelTable+$01,y
 		STA !9E,x
 		LDA.w PerLevelTable+$02,y
@@ -1264,6 +1275,17 @@ CustomStatusPtr:
 ; ---------------------------------------------------
 
 if !PerLevel = 1
+	freedata
+	prot PerLevelSprPtrs
+	prot PerLevelTable
+	prot PerLevelCustomPtrTable
+	PerLevelLvlPtrs:
+		print "Per-level sprite level pointers at ", pc
+		incbin "_PerLevelLvlPtrs.bin"
+	freedata
+	PerLevelSprPtrs:
+		print "Per-level sprite pointers at ", pc
+		incbin "_PerLevelSprPtrs.bin"
 	freedata
 	PerLevelTable:
 		print "Level Table at ", pc

--- a/asm/main.asm
+++ b/asm/main.asm
@@ -1276,22 +1276,32 @@ CustomStatusPtr:
 
 if !PerLevel = 1
 	freedata
-	prot PerLevelSprPtrs
-	prot PerLevelTable
-	prot PerLevelCustomPtrTable
+	prot PerLevelSprPtrs_data
+	prot PerLevelTable_data
+	prot PerLevelCustomPtrTable_data
 	PerLevelLvlPtrs:
 		print "Per-level sprite level pointers at ", pc
 		incbin "_PerLevelLvlPtrs.bin"
 	freedata
-	PerLevelSprPtrs:
-		print "Per-level sprite pointers at ", pc
-		incbin "_PerLevelSprPtrs.bin"
-	freedata
+        ; i have no idea how to explain why i did it like this but trust me it works, and it's necessary to allow the full 0x800 per-level sprites
+        skip -1
 	PerLevelTable:
+        skip 1
+        .data:
 		print "Level Table at ", pc
 		incbin "_PerLevelT.bin"
 	freedata
+        skip -1
 	PerLevelCustomPtrTable:
+        skip 1
+        .data:
 		print "Level Pointers Table at ", pc
 		incbin "_PerLevelCustomPtrTable.bin"
+	freedata
+        skip -1
+	PerLevelSprPtrs:
+        skip 1
+        .data:
+		print "Per-level sprite pointers at ", pc
+		incbin "_PerLevelSprPtrs.bin"
 endif

--- a/make.sh
+++ b/make.sh
@@ -14,5 +14,5 @@ if test ! -e libasar.so ; then
 fi
 
 #### compile
-g++ $CFLAGS -o "pixi" -Wall --std=c++11 -Wno-format $LDFLAGS src/*.cpp src/asar/asardll.c src/json/base64.cpp
+g++ $CFLAGS -o "pixi" -fpermissive -Wall --std=c++11 -Wno-format src/*.cpp src/asar/asardll.c src/MeiMei/*.cpp src/json/base64.cpp -ldl
 #@pause

--- a/src/MeiMei/MeiMei.cpp
+++ b/src/MeiMei/MeiMei.cpp
@@ -6,7 +6,6 @@
 #include <sstream>
 #include <stdio.h>
 
-#include "windows.h"
 #include "Rom.h"
 
 #include "MeiMei.h"

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -54,7 +54,8 @@ unsigned char PLS_SPRITE_PTRS[0x4000];
 int PLS_SPRITE_PTRS_ADDR = 0;
 unsigned char PLS_DATA[0x8000];
 unsigned char PLS_POINTERS[0x8000];
-int PLS_DATA_ADDR = 0; // index into both PLS_DATA and PLS_POINTERS
+// index into both PLS_DATA and PLS_POINTERS
+int PLS_DATA_ADDR = 0;
 
 std::string ASM_DIR_PATH;
 bool disableMeiMei = false;
@@ -272,18 +273,19 @@ void patch_sprites(std::list<std::string>& extraDefines, sprite *sprite_list, in
 		if(spr->level < 0x200 && spr->number >= 0xB0 && spr->number < 0xC0) {
 			int pls_lv_addr = PLS_LEVEL_PTRS[spr -> level * 2] + (PLS_LEVEL_PTRS[spr -> level * 2 + 1] << 8);
 			if(pls_lv_addr == 0x0000) {
-				pls_lv_addr = PLS_SPRITE_PTRS_ADDR;
+				pls_lv_addr = PLS_SPRITE_PTRS_ADDR+1;
 				PLS_LEVEL_PTRS[spr -> level * 2] = (unsigned char)pls_lv_addr;
 				PLS_LEVEL_PTRS[spr -> level * 2 + 1] = (unsigned char)(pls_lv_addr >> 8);
 				PLS_SPRITE_PTRS_ADDR += 0x20;
 			}
+			pls_lv_addr--;
 			pls_lv_addr += (spr -> number - 0xB0) * 2;
 
 			if(PLS_DATA_ADDR >= 0x8000)
 				error("Too many Per-Level sprites.  Please remove some.\n", "");
 			
-			PLS_SPRITE_PTRS[pls_lv_addr] = (unsigned char)PLS_DATA_ADDR;
-			PLS_SPRITE_PTRS[pls_lv_addr+1] = (unsigned char)(PLS_DATA_ADDR >> 8);
+			PLS_SPRITE_PTRS[pls_lv_addr] = (unsigned char)(PLS_DATA_ADDR+1);
+			PLS_SPRITE_PTRS[pls_lv_addr+1] = (unsigned char)(PLS_DATA_ADDR+1 >> 8);
 			
 			memcpy(PLS_DATA+PLS_DATA_ADDR, &spr->table, 0x10);
 			memcpy(PLS_POINTERS+PLS_DATA_ADDR, &spr->ptrs, 15);
@@ -1154,7 +1156,7 @@ int main(int argc, char *argv[])
 	write_all(versionflag, paths[ASM], "_versionflag.bin", 4);
    if(PER_LEVEL) {
 		write_all(PLS_LEVEL_PTRS, paths[ASM], "_PerLevelLvlPtrs.bin", 0x400);
-		if(PLS_DATA_ADDR) {
+		if(PLS_DATA_ADDR == 0) {
 			unsigned char dummy[1] = {0xFF};
 			write_all(dummy, paths[ASM], "_PerLevelSprPtrs.bin", 1);
 			write_all(dummy, paths[ASM], "_PerLevelT.bin", 1);


### PR DESCRIPTION
split PLS_DATA into 3 tables, PLS_LEVEL_PTRS, PLS_SPRITE_PTRS and PLS_DATA. This means that all indexes into PLS_DATA have corresponding indexes into PLS_POINTERS, so no parts of PLS_POINTERS are wasted. Also it allows the full 2048 per-level sprites to be used, previously you could only use between 960 and 1762 depending on how many levels have per-level sprites (if all 0x200 levels had at least a single per-level sprite, then you could only have 960 in total).

also fixes building pixi on linux.